### PR TITLE
Force component defaults to false for the web interface

### DIFF
--- a/controller/main.php
+++ b/controller/main.php
@@ -195,6 +195,7 @@ class main
 		$components = $this->packager->get_component_dialog_values();
 		foreach ($components as $component => $details)
 		{
+			$details['default'] = false;
 			foreach ($details['dependencies'] as $depends)
 			{
 				if (empty($this->data['components'][$depends]))


### PR DESCRIPTION
Fixes #6

On the web interface, the defaults for the components needs to be false. Otherwise all components are always generated despite the checked boxes.
